### PR TITLE
feat: switching network when someone aren't into fantom mainnet

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -7,6 +7,7 @@ import ConnectWallet from "../components/ConnectWallet";
 import Footer from "../components/Footer";
 import Link from "next/link";
 import { extractColorFrom } from "../utils/fantomKittensDict";
+import { requestSwitchToFantomChain } from "../utils/web3"
 import KittenPanel from "../components/KittenPanel";
 
 function computeColorTraitFromRgbTrait(rgbTrait) {
@@ -38,6 +39,11 @@ export default function Home() {
       await activate(injected, undefined, true);
       postWalletConnection();
     } catch (ex) {
+      if (ex.name === 'UnsupportedChainIdError') {
+        await requestSwitchToFantomChain();
+        await activate(injected, undefined, true);
+        postWalletConnection();
+      }
       console.error(ex);
     }
   }

--- a/utils/web3.js
+++ b/utils/web3.js
@@ -1,3 +1,5 @@
+const toHex = (num) => '0x' + num.toString(16)
+
 export function getTransactionsByAccount(eth, myaccount, startBlockNumber, endBlockNumber) {
   if (endBlockNumber == null) {
     endBlockNumber = eth.blockNumber;
@@ -32,5 +34,43 @@ export function getTransactionsByAccount(eth, myaccount, startBlockNumber, endBl
         }
       })
     }
+  }
+}
+
+async function addFantomChainToWallet() {
+  return window.ethereum.request({
+    method: "wallet_addEthereumChain",
+    params: [
+      {
+        chainId: toHex(250),
+        chainName: "Fantom Opera",
+        nativeCurrency: {
+          name: "Fantom",
+          symbol: "FTM",
+          decimals: 18
+        },
+        blockExplorerUrls: ["https://ftmscan.com/"],
+        rpcUrls: ["https://rpc.ftm.tools/"],
+      }, address
+    ],
+  });
+}
+
+async function switchToFantomChain() {
+  return window.ethereum.request({
+    method: "wallet_switchEthereumChain",
+    params: [{ chainId: toHex(250) }]
+  });
+}
+
+export async function requestSwitchToFantomChain() {
+  try {
+    await switchToFantomChain();
+  } catch (error) {
+    if (error.code === 4902) {
+      await addFantomChainToWallet();
+      return;
+    }
+    console.log(error)
   }
 }


### PR DESCRIPTION
this PR allows users that are current in other networks to switch to fantom network just by clicking on connect wallet button!

I have tested these three cases:

Should just connect when someone is already into fantom network ✅
Should switch the network and connect from someone who already has fantom network added in their metamask ✅
Should add the fantom network, switch, and connect from someone who doesn't have the fantom network in metamask ✅

Ps: I didn't find how to switch the chain using `web3-react`, if there's a way please DM me on Discord and I'll fix it! 
my discord: `nicolau#0040`